### PR TITLE
Updated the declaration of the book command to current syntax.

### DIFF
--- a/bible.cls
+++ b/bible.cls
@@ -28,7 +28,7 @@
 \setcounter{book}{0}
 \bool_new:c{is_first_verse}
 \bool_new:c{is_first_chap}
-\DeclareDocumentCommand{\book}{om}{
+\DeclareDocumentCommand{\book}{omo}{
   % #1 keys
   % #2 title
   % #3 key (default #2)


### PR DESCRIPTION
Updated the book declaration to work with current versions of xparse.

Fixes the error: `! Illegal parameter number in definition of \book code. 3 l.55 }`

Issue discovered and diagnosed at http://tex.stackexchange.com/questions/360727/illegal-parameter-number-in-definition-of-book-code
